### PR TITLE
Why Fedimint page copy suggestions

### DIFF
--- a/docs/GettingStarted/01-Why-Fedimint.md
+++ b/docs/GettingStarted/01-Why-Fedimint.md
@@ -22,37 +22,37 @@ Fedimint is built on three guiding pillars.
 
 Ideally bitcoiners should run their own nodes and custody their own funds.
 
-Many people find the technical challenges of running their own nodes and holding their own funds through seed management prohibitively difficult, and opt into trusting a third party custodian like exchanges or custodial wallets. 
+Many people find the technical challenges of running their own nodes and holding their own funds through recovery phrase management prohibitively difficult, and opt into trusting a third party custodian like exchanges or custodial wallets. 
 
-These users will sacrifice their privacy and security in favor of speed and convenience and this arrangement can represent a systemic risk to the bitcoin network as large quantities of bitcoin are aggregated into single custodians.
+These users sacrifice their privacy and security in favor of speed and convenience. This represents a systemic risk to the bitcoin network as large quantities of bitcoin are aggregated into single custodians.
 
-Fedimint aims to address this by distributing the custodianship across millions of communities, making it simple for communities to bank themselves. 
+Fedimint aims to address this by distributing custodianship across millions of communities, making it simple for them to bank themselves. These community focused 'banks' are known as Fedimint Federations.  
 
 We are building a solution which allows users to onboard to Bitcoin in a manner they find extremely convenient, without sacrificing privacy and security.
 
-Fedimint allows Bitcoiners to onboard new bitcoiners themselves, assisting them in their custody and payment model. Instead of referring a new bitcoiner to a third party custodian, you can onboard them yourself as part of a Federation.
+Fedimint allows bitcoiners to onboard new users, assisting them in their custody and payment model. Instead of referring a new bitcoiner to a third party custodian, you can onboard them yourself as part of a Federation.
 
 Put another way it allows you to **be your mum's / friends / villages bank**. 
 
-We call these close, trusted relationships "2nd party custodians".  Fedimint federation guardians should be close friends and family members that you know personally, and can directly influence should they ever attempt to violate your trust.
+We call these close, trusted relationships "2nd party custodians". Fedimint federation guardians should be close friends and family members that you know personally, and can directly influence should they ever attempt to violate your trust.
 
 This provides bitcoiners with a third option between 3rd party centralized custodians and self custody as shown in the figure below.
 
 ![The spectrum and trade offs for Fedimint Custody](/img/raw-figures/fm-spectrum-custody.excalidraw.png)
 
-Most importantly, Fedimint is directly interoperable with the Lightning Network. Any Fedimint user can at any time move their funds into their own lightning wallet or onto their own node.
+Most importantly, Fedimint is interoperable with the Lightning Network. Fedimint users can at any time move their funds into their own self-custody lightning wallet.
 
-This allows Fedimint users to remain part of the wider lightning network merchants, making instant payments and moving between Fedimints without managing additional complexity.
+This allows Fedimint users to remain apart of the wider lightning network, making it possible to pay merchants, other users, or even move between Fedimints.
 
-As such as a user who previously may have used 3rd party custody for convenience can retain that convenience whilst improving their privacy and control of their finances.
+As such, a user who previously used a 3rd party custodian for convenience can retain that convenience whilst improving their privacy and control of their finances.
 
 :::note
-There is a [trade off ](../TradeOffs/NotYOurKeys) here as you are trusting a federation with your bitcoin custody. As such it will be important to "know your federation".
+There is a [trade off ](../TradeOffs/NotYOurKeys) here as you are trusting a federation with your bitcoin. As such it will be important to "know your federation".
 :::
 
 ## Financial Privacy
 
-Fedimint uses [Chaumain e-cash tokens and blinded signatures](/docs/CommonTerms/Blind%20Signatures) to achieve perfect privacy for federation members. Federation guardians cannot correlate inputs and outputs of federation members' transactions, and cannot see the holdings of any individual federation member.
+Fedimint uses [Chaumain e-cash tokens and blinded signatures](/docs/CommonTerms/Blind%20Signatures) to achieve privacy for federation members. Federation guardians cannot correlate inputs and outputs of federation members' transactions, and cannot see the holdings of any individual federation member.
 
 ![The spectrum and trade offs for Fedimint Custody](/img/raw-figures/fm-privacy-firewall.excalidraw.png)
 
@@ -93,7 +93,7 @@ If we tried to connect every address in town one, with town two then we would ov
 We believe this model will allow us to build a more flexible and scalable and efficient lightning network.
 
 :::note
-There is [some recent research](https://github.com/renepickhardt/mpp-splitter/issues/12#issuecomment-1143772489) on how to scale lightning that suggests the possibility of widespread use of fedimint federations could increase the efficiency of the lightning network while also increasing the potential fees an LSP can earn due to increased liquidity.
+There is [some recent research](https://github.com/renepickhardt/mpp-splitter/issues/12#issuecomment-1143772489) on how to scale lightning that suggests the possibility of widespread use of Fedimint Federations could increase the efficiency of the lightning network while also increasing the potential fees a Lightning Service Provider (LSP) could earn due to increased demand.
 :::
 
 ---


### PR DESCRIPTION
Other points

- Bit of jumping around between using Fedimint, Federation, and mint to describe the same thing - would be clearer to stick with just one term. 
- Some concepts are introduced without prior explaining. E.g. "- The **total amount** of bitcoin held in the community multi-sig wallet." in financial privacy - it's not explained prior to this that a multisig-wallet is used at all, could be confusing to some.
- A glossary would be handy for some jargon terms
- Wonder if interoperability is a fourth pillar that deserves its own distinction on the Why Fedimint page - seems pretty important to just put as a stub at the end of community custody
- Do we want to call these 'banks' 🥷