### PR TITLE
Update 01-Why-Fedimint.md

### DIFF
--- a/docs/GettingStarted/01-Why-Fedimint.md
+++ b/docs/GettingStarted/01-Why-Fedimint.md
@@ -52,7 +52,7 @@ There is a [trade off ](../TradeOffs/NotYOurKeys) here as you are trusting a fed
 
 ## Financial Privacy
 
-Fedimint uses [Chaumain e-cash notes and blinded signatures](/docs/CommonTerms/Blind%20Signatures) to achieve privacy for federation members. Federation guardians cannot correlate inputs and outputs of federation members' transactions, and cannot see the holdings of any individual federation member.
+Fedimint uses [Chaumain e-cash notes](/docs/CommonTerms/Blind%20Signatures) by utilizing blinded signatures to achieve privacy for federation members. Federation guardians cannot correlate inputs and outputs of federation members' transactions, and cannot see the holdings of any individual federation member.
 
 ![The spectrum and trade offs for Fedimint Custody](/img/raw-figures/fm-privacy-firewall.excalidraw.png)
 


### PR DESCRIPTION
A small nit: I think an e-cash note is defined by how it is created e.g with blind signatures. There are no chaumian  e-cash notes that  do not use blinded signatures (? not sure actually)

Also (just a suggestion), maybe add a magnifying glass icon to the red arrow pointing from the lightning network map to the fedimint map (line 85). I was confused for a second there.