### PR TITLE
docs: fix typos

### DIFF
--- a/docs/GettingStarted/01-Why-Fedimint.md
+++ b/docs/GettingStarted/01-Why-Fedimint.md
@@ -60,7 +60,7 @@ There is a [trade off ](../TradeOffs/NotYOurKeys) here as you are trusting a fed
 
 ## Financial Privacy
 
-Fedimint uses [Chaumain eCash notes and blinded signatures](/docs/CommonTerms/Blind%20Signatures) to achieve privacy for federation members. Federation guardians cannot correlate inputs and outputs of federation members' transactions, and cannot see the holdings of any individual federation member.
+Fedimint uses [Chaumian eCash notes and blinded signatures](/docs/CommonTerms/Blind%20Signatures) to achieve privacy for federation members. Federation guardians cannot correlate inputs and outputs of federation members' transactions, and cannot see the holdings of any individual federation member.
 
 <div style={{textAlign: 'center'}}>
 

--- a/docs/TradeOffs/03-DebasementRisk.md
+++ b/docs/TradeOffs/03-DebasementRisk.md
@@ -35,7 +35,7 @@ To expand on this, at all times the mint has both assets and liabilities which s
 
 The guardians of the federation have access to the required information that allows them to balance the books between the eCash outstanding and the assets held on chain.
 
-For the user however, whilst they can see the assets on chain, they have no view of the total number of outstanding liabilities and so the users is always "unable to verify" the total asset and liability balance of the federation, as such they are trusting the guardians to manage this balance.
+For the user however, whilst they can see the assets on chain, they have no view of the total number of outstanding liabilities and so the user is always "unable to verify" the total asset and liability balance of the federation, as such they are trusting the guardians to manage this balance.
 
 This mismatch is at the core of this risk as it means that no external party to the guardians can audit the supply and marks the importance of strong 2nd party trust in federation guardians.
 
@@ -99,12 +99,12 @@ The impact of this activity is two fold:
 ## The Mitigation
 
 :::info
-This section is under active review. PRs and discussion are appreciated on the Fedimint telgram, discord or github.
+This section is under active review. PRs and discussions are appreciated on the Fedimint telgram, discord or github.
 :::
 
 In mitigating this risk we should consider the options to both stop false claims and raise the alarm on discovery of false claims.
 
-Whilst several mitigation activities will be outlined, the tl;dr is that a user can't verify the holdings of mint, however, several activities and alerts can be built around the mint to trigger warnings of misconduct.
+Whilst several mitigation activities will be outlined, the tl;dr is that a user can't verify the holdings of the mint, however, several activities and alerts can be built around the mint to trigger warnings of misconduct.
 
 ### In Mint Audits
 
@@ -116,7 +116,7 @@ It should be noted that if there is a quorum of bad guardians then these liabili
 
 An honest guardian could track the volume and value of eCash notes that have been signed whilst they have been in the quorum. They would also be aware of their own up-time.
 
-Using these two data points they could estimate the likelihood of debasement if the level of redemptions to the mint causes the can raise alarm on increased redemptions of honest
+Using these two data points they could estimate the likelihood of debasement if the level of redemptions to the mint causes concern and can raise alarm on the increased rate of redemptions.
 
 ### Know Your Federation
 

--- a/docs/TradeOffs/04-RegulatoryRisk.md
+++ b/docs/TradeOffs/04-RegulatoryRisk.md
@@ -6,7 +6,7 @@ This guide has been developed as a community project and is a live document. We 
 
 The Fedimint protocol has been designed to fit a particular regulatory niche. One in which people custody assets for friends, family and community interests, where there is no profit motive. 
 
-This risk deals with the threat of changing regulations meaning this is no longer the case and the mint is forced to shut down or divulge user information. 
+This risk deals with the threat of changing regulations, meaning this is no longer the case, and the mint is forced to shut down or divulge user information.
 
 This is a nuanced area that will need to be explored on a per Fedimint basis dependant on the laws in the local jurisdiction and the way a Fedimint is set up and operated. 
 


### PR DESCRIPTION
- 01-Why-Fedimint.md: Fixes a typo in the Chaumian eCash and Blind Signatures link.
- 03-DebasementRisk: Fix typos and incomplete sentences.
- 04-RegulatoryRisk: Fix punctuation.