### PR TITLE
Grammatical and description updates to the "What is a Fediment" page

### DIFF
--- a/docs/GettingStarted/03-What-is-a-Fedimint.md
+++ b/docs/GettingStarted/03-What-is-a-Fedimint.md
@@ -74,7 +74,7 @@ To send a lightning payment, the Fedimint User locks eCash notes to a contract w
 To receive a payment, the Fedimint User broadcasts a tweaked invoice to the lightning gateway. The User reveals the tweak, allowing the gateway to receive the lightning payment, in exchange for eCash notes.
 
 - **Account & Onboard:** Similar to a user the Lightning Service provider will need to be comfortable accepting the federations fm-BTC in exchange for providing a liquidity bridge to the lightning network.
-- **Custody & Redemption:** As per user persona. It is more likely a Lightning Gateway user would require the redemption and deposit service in order to more actively balance fm-BTC, lighting and on-chain balances.
+- **Custody & Redemption:** Similar to the federation guardians, the Lightning Gateway user can use the redemption and deposit service in order to more actively balance fm-BTC, lightning, and on-chain bitcoin balances.
 - **Backup & Recovery:** As per user persona.
 - **Transaction Processing:** As per user persona. The Lightning Gateway would also be running additional daemon software to automate the process of accepting contracts for lighting services ([more details in FAQs > Lightning Network Integration](How-FM-Transactions-Work))
 

--- a/docs/GettingStarted/03-What-is-a-Fedimint.md
+++ b/docs/GettingStarted/03-What-is-a-Fedimint.md
@@ -39,7 +39,7 @@ The federation guardians are specific roles within the system that can only be a
 - **Account & Onboard:** The federation guardians will run the Fedimint protocol software stack. This will allow the guardians to generate a "joining a federation QR Code".
 - **Custody & Redemption:** The federation guardians will hold private keys to the threshold multi signature contract into which bitcoin is deposited. When a user executes a deposit process they will also blind sign eCash certificates to an amount equivalent to the deposited bitcoin.
 - **Backup & Recovery:** Federation members will manage the back up of "shards" (individual parts of complete file) of users' wallet data. When a recovery request is made they will manage an out of band process to confirm the authenticity of the recovery request, the identity of the federation member attempting to recover funds, and coordinate with other federation members to reconstruct the shard and recover the user's funds.
-- **Transaction Processing:** review transactions submitted to the federation to ensure that only valid eCash certificates are redeemed and that new eCash certificates are generated where required ([see how do FM transactions work?](How-FM-Transactions-Work)).
+- **Transaction Processing:** The federation guardians review transactions submitted to the federation to ensure that only valid eCash certificates are redeemed and that new eCash certificates are generated where required ([see how do FM transactions work?](How-FM-Transactions-Work)).
 
 ### Fedimint Users
 
@@ -63,13 +63,13 @@ These are not account balances but equivalent to digital banknotes of specific s
 
 ### Lightning Gateway Provider
 
-The Lighting Gateway is a Fedimint User who also runs a lightning node. 
+The Lighting Gateway is a Fedimint User who also runs a lightning node.
 
 A federation may opt to run its own lightning gateway as well, but we have intentionally architected Fedimint such that any user can act as a lightning gateway to interact with the broader lighting network outside of the mint.
 
-The Lightning Gateway monitors the Federation for user requests to pay Lightning invoices or receive lightning payments. 
+The Lightning Gateway monitors the Federation for user requests to pay Lightning invoices or receive lightning payments.
 
-To send a lightning payment, the Fedimint User locks eCash notes to a contract which contains a lightning invoice. The lightning gateway can sweep the eCash notes from the contract by paying the lightning invoice. 
+To send a lightning payment, the Fedimint User locks eCash notes to a contract which contains a lightning invoice. The lightning gateway can sweep the eCash notes from the contract by paying the lightning invoice.
 
 To receive a payment, the Fedimint User broadcasts a tweaked invoice to the lightning gateway. The User reveals the tweak, allowing the gateway to receive the lightning payment, in exchange for eCash notes.
 


### PR DESCRIPTION
Fixed an incomplete sentence in the federation guardians' **Transaction Processing** section. Also, removed some trailing whitespace in the doc.

Based on a conversation with @justinmoon, it's possible that the LGP may, by default and similar to federation guardians, have the ability to perform the redemption and deposit service. Hopefully the offered update will be more accurate.